### PR TITLE
Feature/refactor and decoupling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ It also incorporates ***queue mechanism*** with redis, so that it is more flexib
 
 ## Start Modes
 This app has two modes to start:
-1. `slackbot` - listens to slack event for user requests, put request to redis as queue
-2. `chatgpt` - serves as queue worker that listens to queue, forward user's questions to chatgpt, and write to slack on answer.
+1. `slackbot` - listens to slack event for user requests, put request to redis queue, reply to slack on answer received.
+2. `chatgpt` - serves as queue worker that listens to queue, forward user's questions to chatgpt, and put response back to queue on answer received.
 
 ## Setup
 
@@ -37,6 +37,9 @@ docker run chatgpt_slackbot
 |`SLACK_BOT_TOKEN`|Y|Your Slack Bot token. See https://api.slack.com/|
 |`SLACK_APP_TOKEN`|Y|Your Slack App token. See https://api.slack.com/|
 |`SLACK_BOT_USER_ID`|Y|The User ID of your Slack Bot. See https://api.slack.com/|
+|`SLACK_REACTION_LOADING`|N|The emoji to react when loading a question, default `thinking_face`
+|`SLACK_REACTION_SUCCESS`|Y|The emoji to react when the prompt is answered, default `white_trade_mark`
+|`SLACK_REACTION_FAILED`|Y|The emoji to react when failed when processing, default `x`
 |`CHATGPT_EMAIL`|Y|The email of your chatgpt account|
 |`CHATGPT_PASSWORD`|Y|The password of your chatgpt account|
 |`CHATGPT_PROXY_SERVER`|N|e.g.: 12.123.234.345:23456, leave it blank if not used|

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ docker run chatgpt_slackbot
 |`CHATGPT_PROXY_SERVER`|N|e.g.: 12.123.234.345:23456, leave it blank if not used|
 |`CHATGPT_IS_GOOGLE_LOGIN`|N|1 or 0, default 0|
 |`CHATGPT_REQUEST_TIMEOUT_MS`|N|Timeout value for chatgpt request. default 300000 (5min)|
-|`QUEUE_INTERVAL_MS`|N|Interval between handling each queue item in ms. default 3000|
 
 ## Usage
 - The slackbot will listen to two types of event in slack workspace

--- a/src/app.js
+++ b/src/app.js
@@ -13,20 +13,27 @@ async function main() {
     if (!START_MODE_OPTIONS.includes(process.env.START_MODE)) {
         throw new Error('Invalid start mode');
     }
-    if (!process.env.SLACK_BOT_TOKEN || !process.env.SLACK_APP_TOKEN) {
-        throw new Error('Missing slack token');
-    };
 
     RedisAgent.initialize({
         redisUrl: process.env.REDIS_URL,
     });
 
-    const slackBot = new ChatGtpSlackBot({
-        slackBotToken: process.env.SLACK_BOT_TOKEN,
-        slackAppToken: process.env.SLACK_APP_TOKEN,
-    });
-
     if (process.env.START_MODE === 'slackbot') {
+
+        if (!process.env.SLACK_BOT_TOKEN || !process.env.SLACK_APP_TOKEN) {
+            throw new Error('Missing slack token');
+        };
+    
+        const slackBot = new ChatGtpSlackBot({
+            slackBotToken: process.env.SLACK_BOT_TOKEN,
+            slackAppToken: process.env.SLACK_APP_TOKEN,
+            reactions: {
+                loading: process.env.SLACK_REACTION_LOADING,
+                success: process.env.SLACK_REACTION_SUCCESS,
+                failed: process.env.SLACK_REACTION_FAILED,
+            },
+        });
+        
         await slackBot.listen();
         
     } else if (process.env.START_MODE === 'chatgpt') {
@@ -43,15 +50,8 @@ async function main() {
             requestTimeoutMs: Number(process.env.CHATGPT_REQUEST_TIMEOUT_MS || 300000),
         });
 
-        chatGptClient.setCallbacks(async (answer, question, slackMeta, chatgptClientId) => {
-            await slackBot.replyAnswer(answer, question, slackMeta, chatgptClientId);
-        }, async (error, question, slackMeta, chatgptClientId) => {
-            await slackBot.replyError(error, question, slackMeta, chatgptClientId);
-        });
-
         await chatGptClient.startChatGptSession();
-        await chatGptClient.startListenQueue();
-        
+        await chatGptClient.listenQuestion();
     }
 
 }

--- a/src/app.js
+++ b/src/app.js
@@ -41,7 +41,6 @@ async function main() {
             isGoogleLogin: Boolean(Number(process.env.CHATGPT_IS_GOOGLE_LOGIN)),
             proxyServer: process.env.CHATGPT_PROXY_SERVER,
             requestTimeoutMs: Number(process.env.CHATGPT_REQUEST_TIMEOUT_MS || 300000),
-            queueIntervalMs: Number(process.env.QUEUE_INTERVAL_MS || 3000),
         });
 
         chatGptClient.setCallbacks(async (answer, question, slackMeta, chatgptClientId) => {

--- a/src/chatgpt-client.js
+++ b/src/chatgpt-client.js
@@ -10,7 +10,6 @@ import crypto from 'crypto';
  * @property {boolean} [isGoogleLogin]
  * @property {string|undefined} [proxyServer]
  * @property {number} [requestTimeoutMs]
- * @property {number} [queueIntervalMs]
  */
 
 /**
@@ -68,9 +67,6 @@ class ChatGptClient {
         /** @type {number} */
         this.requestTimeoutMs = args.requestTimeoutMs ?? 5 * 60 * 1000;
 
-        /** @type {number} */
-        this.queueIntervalMs = args.queueIntervalMs ?? 3000;
-
         /** @type {AnswerCallback} */
         this.answerCallback = null;
 
@@ -127,7 +123,7 @@ class ChatGptClient {
         while (true) {
             await this._popAndHandle(`ChatGptClient.COMMON`);
             await this._popAndHandle(`ChatGptClient.${this.clientId}`);
-            await new Promise(r => setTimeout(r, this.queueIntervalMs));
+            await new Promise(r => setTimeout(r, 1000));
         }
     }
 

--- a/src/chatgpt-client.js
+++ b/src/chatgpt-client.js
@@ -17,6 +17,7 @@ import crypto from 'crypto';
  * @property {string} prompt
  * @property {string} [conversationId]
  * @property {string} [parentMessageId]
+ * @property {string} [responseQueue]
  */
 
 /**
@@ -27,22 +28,19 @@ import crypto from 'crypto';
  */
 
 /**
- * @callback AnswerCallback
- * @param {ChatGptAnswer} answer
- * @param {ChatGptQuestion} question
- * @param {SlackMeta} slackMeta
- * @param {string} chatgptClientId
+ * @typedef ChatGptCallbackParam
+ * @property {boolean} success
+ * @property {string} handlerId
+ * @property {ChatGptQuestion} question
+ * @property {ChatGptAnswer} [answer]
+ * @property {Error} [error]
+ * @property {*} [extra]
  */
 
 /**
- * @callback ErrorCallback
- * @param {Error} err
- * @param {ChatGptQuestion} question
- * @param {SlackMeta} slackMeta
- * @param {string} chatgptClientId
+ * @callback ChatGptCallback
+ * @param {ChatGptCallbackParam} param
  */
-
-
 class ChatGptClient {
 
     /**
@@ -62,40 +60,30 @@ class ChatGptClient {
         this.accEmail = args.accEmail;
 
         /** @type {string} */
-        this.clientId = this._obtainClientId();
+        this.handlerId = this._obtainHandlerId();
 
         /** @type {number} */
         this.requestTimeoutMs = args.requestTimeoutMs ?? 5 * 60 * 1000;
-
-        /** @type {AnswerCallback} */
-        this.answerCallback = null;
-
-        /** @type {ErrorCallback} */
-        this.errorCallback = null;
     }
 
     /**
-     * @param {AnswerCallback} answerCallback
-     * @param {ErrorCallback} errorCallback
-     */
-    setCallbacks(answerCallback, errorCallback) {
-        this.answerCallback = answerCallback;
-        this.errorCallback = errorCallback;
-    }
-
-    /**
-     * Ask ChatGPT asyncrhonously
-     * @param {ChatGptQuestion} question
-     * @param {SlackMeta} slackMeta
-     * @param {string} [chatgptClientId]
+     * Ask ChatGPT Asyncrhonously. Requests will be enqueued to a queue system for handlers to process. 
+     * The result will be returned through an answer queue provided by caller.
+     * @param {ChatGptQuestion} question Question
+     * @param {object} opts
+     * @param {string} opts.responseQueue The name of the queue that the answer should be enqueued to.
+     * @param {string} [opts.handlerId] In case a specific handler should be used to answer the question. Mostly used in case of follow up questions.
+     * @param {*} [opts.extra] Any extra information that will returned along with the answer.
      * @return {Promise<ChatResponse>}
      */
-    static async ask(question, slackMeta, chatgptClientId = undefined) {
+    static async ask(question, opts) {
 
-        if (chatgptClientId) {
-            await RedisAgent.getInstance().enqueue(`ChatGptClient.${chatgptClientId}`, { question, slackMeta });
+        const { responseQueue, handlerId, extra } = opts;
+
+        if (handlerId) {
+            await RedisAgent.getInstance().enqueue(`queues.questions.handler.${handlerId}`, { question, extra, responseQueue });
         } else {
-            await RedisAgent.getInstance().enqueue(`ChatGptClient.COMMON`, { question, slackMeta });
+            await RedisAgent.getInstance().enqueue(`queues.questions.handler.common`, { question, extra, responseQueue });
         }
     }
 
@@ -104,7 +92,7 @@ class ChatGptClient {
      * @returns {Promise<void>}
      */
     async startChatGptSession() {
-        console.info(`[${new Date().toISOString()}] CHATGPT_CONNECTING_SESSION`);
+        console.info(`[${new Date().toISOString()}] CHATGPT_CONNECTING_SESSION <${this.accEmail}>`);
         try {
             await this.chatApi.initSession();
         } catch (err) {
@@ -118,17 +106,32 @@ class ChatGptClient {
      * The account specific queue is used in case that a root question is processed by a specific account previously 
      * therefore its follow-up must also be processed by the same account.
      */
-    async startListenQueue() {
-        console.info(`[${new Date().toISOString()}] CHATGPT_START_LISTEN_QUEUE`);
+    async listenQuestion() {
+        console.info(`[${new Date().toISOString()}] CHATGPT_START_LISTEN_QUEUE <${this.accEmail}>`);
         while (true) {
-            await this._popAndHandle(`ChatGptClient.COMMON`);
-            await this._popAndHandle(`ChatGptClient.${this.clientId}`);
+            await this._popAndHandle(`queues.questions.handler.common`);
+            await this._popAndHandle(`queues.questions.handler.${this.handlerId}`);
             await new Promise(r => setTimeout(r, 1000));
         }
     }
 
     /**
-     * Pops one item from queue and try to handle it
+     * @param {string} answerQueueName
+     * @param {ChatGptCallback} callback 
+     */
+    static async listenAnswer(answerQueueName, callback) {
+        while (true) {
+            /** @type {ChatGptCallbackParam} */
+            let item = await RedisAgent.getInstance().dequeue(answerQueueName);
+            if (item) {
+                await callback(item);
+            }
+            await new Promise(r => setTimeout(r, 1000));
+        }
+    }
+
+    /**
+     * Pops one item from queue and try to handle it. 
      * @param {string} queueName 
      */
     async _popAndHandle(queueName) {
@@ -136,9 +139,21 @@ class ChatGptClient {
         if (item) {
             try {
                 const answer = await this._handleAsk(item.question, true);
-                await this.answerCallback(answer, item.question, item.slackMeta, this.clientId);
+                await RedisAgent.getInstance().enqueue(item.responseQueue, {
+                    success: true,
+                    answer,
+                    question: item.question,
+                    extra: item.extra,
+                    handlerId: this.handlerId
+                });
             } catch (err) {
-                await this.errorCallback(err, item.question, item.slackMeta, this.clientId);
+                await RedisAgent.getInstance().enqueue(item.responseQueue, {
+                    success: false,
+                    error: err,
+                    question: item.question,
+                    extra: item.extra,
+                    handlerId: this.handlerId
+                });
             }
         }
     }
@@ -178,7 +193,7 @@ class ChatGptClient {
     /**
      * Returns a hash string from account email 
      */
-    _obtainClientId() {
+    _obtainHandlerId() {
         const hash = crypto.createHash('sha256');
         hash.update(this.accEmail);
         const hashedEmail = hash.digest('hex');

--- a/src/slackbot.js
+++ b/src/slackbot.js
@@ -13,8 +13,11 @@ import ChatGptClient from './chatgpt-client.js';
  * @typedef ChatGtpSlackBotArgs
  * @property {string} slackBotToken
  * @property {string} slackAppToken
+ * @property {object} reactions
+ * @property {string} reactions.loading
+ * @property {string} reactions.success
+ * @property {string} reactions.failed
  */
-
 class ChatGtpSlackBot {
 
     /**
@@ -27,6 +30,13 @@ class ChatGtpSlackBot {
             appToken: args.slackAppToken,
             socketMode: true
         });
+
+        /** @type {{loading:string, success:string, failed:string}} */
+        this.reactions = {
+            loading: args.reactions?.loading || 'thinking_face',
+            success: args.reactions?.success || 'white_check_mark',
+            failed: args.reactions?.failed || 'x'
+        };
     }
 
     /**
@@ -60,6 +70,13 @@ class ChatGtpSlackBot {
         });
 
         await this.slackApp.start();
+        await ChatGptClient.listenAnswer('queues.answers.chatgpt_slackbot', async (param) => {
+            if (param.success) {
+                await this._replyAnswer(param.answer, param.question, param.extra, param.handlerId);
+            } else {
+                await this._replyError(param.error, param.question, param.extra, param.handlerId);
+            }
+        });
     }
 
 
@@ -67,7 +84,7 @@ class ChatGtpSlackBot {
      * In case the user is asking follow-up question in thread, try to obtain the previous chatgpt answer from the thread.
      * @param {string} channel 
      * @param {string} thread_ts 
-     * @return {Promise<{conversationId: string, parentMessageId: string, chatgptClientId:string}>}
+     * @return {Promise<{conversationId: string, parentMessageId: string, handlerId:string}>}
      */
     async _findPreviousChatGptMessage(channel, thread_ts) {
         
@@ -82,7 +99,7 @@ class ChatGtpSlackBot {
                         return {
                             conversationId: matches[1],
                             parentMessageId: matches[2],
-                            chatgptClientId: matches[3],
+                            handlerId: matches[3],
                         }
                     }
                 }
@@ -95,33 +112,41 @@ class ChatGtpSlackBot {
      * @param {ChatGptAnswer} answer 
      * @param {ChatGptQuestion} question 
      * @param {SlackMeta} slackMeta 
-     * @param {string} chatgptClientId
+     * @param {string} chatgptHandlerId
      */
-    async replyAnswer(answer, question, slackMeta, chatgptClientId) {
+    async _replyAnswer(answer, question, slackMeta, chatgptHandlerId) {
         await this.slackApp.client.chat.postMessage({
             channel: slackMeta.channel,
             thread_ts: slackMeta.ts,
-            text: `${answer.response}\n\n_ref:${answer.conversationId}:${answer.messageId}:${chatgptClientId}_`
+            text: `${answer.response}\n\n_ref:${answer.conversationId}:${answer.messageId}:${chatgptHandlerId}_`
         });
-        await this.slackApp.client.reactions.add({ channel: slackMeta.channel, name: 'white_check_mark', timestamp: slackMeta.ts });
-        await this.slackApp.client.reactions.remove({ channel: slackMeta.channel, name: 'thinking_face', timestamp: slackMeta.ts });
+        if (this.reactions.success) {
+            await this.slackApp.client.reactions.add({ channel: slackMeta.channel, name: this.reactions.success, timestamp: slackMeta.ts });
+        }
+        if (this.reactions.loading) {
+            await this.slackApp.client.reactions.remove({ channel: slackMeta.channel, name: this.reactions.loading, timestamp: slackMeta.ts });
+        }
     }
 
     /**
      * @param {Error} err
      * @param {ChatGptQuestion} question 
      * @param {SlackMeta} slackMeta 
-     * @param {string} chatgptClientId
+     * @param {string} chatgptHandlerId
      */
-    async replyError(err, question, slackMeta, chatgptClientId) {
+    async _replyError(err, question, slackMeta, chatgptHandlerId) {
         await this.slackApp.client.chat.postMessage({
             channel: slackMeta.channel,
             thread_ts: slackMeta.ts, 
             text: `Error: ${err.message} \nPlease ask again...`
         });
         
-        await this.slackApp.client.reactions.add({ channel: slackMeta.channel, name: 'x', timestamp: slackMeta.ts });
-        await this.slackApp.client.reactions.remove({ channel: slackMeta.channel, name: 'thinking_face', timestamp: slackMeta.ts });
+        if (this.reactions.failed) {
+            await this.slackApp.client.reactions.add({ channel: slackMeta.channel, name: this.reactions.failed, timestamp: slackMeta.ts });
+        }
+        if (this.reactions.loading) {
+            await this.slackApp.client.reactions.remove({ channel: slackMeta.channel, name: this.reactions.loading, timestamp: slackMeta.ts });
+        }
     }
 
     /**
@@ -140,12 +165,22 @@ class ChatGtpSlackBot {
             prevAns = await this._findPreviousChatGptMessage(slackMeta.channel, slackMeta.thread_ts, this.slackApp.client);
         }
         // Leave loading reaction
-        const reaction = await this.slackApp.client.reactions.add({ channel: slackMeta.channel, name: 'thinking_face', timestamp: slackMeta.ts });
-        await ChatGptClient.ask({
+        if (this.reactions.loading) {
+            const reaction = await this.slackApp.client.reactions.add({ channel: slackMeta.channel, name: this.reactions.loading, timestamp: slackMeta.ts });
+        }
+
+        /** @type {ChatGptQuestion} */
+        const question = {
             prompt,
             conversationId: prevAns?.conversationId, 
-            parentMessageId: prevAns?.parentMessageId
-        }, slackMeta, prevAns?.chatgptClientId);
+            parentMessageId: prevAns?.parentMessageId,
+        };
+        
+        await ChatGptClient.ask(question, {
+            responseQueue: 'queues.answers.chatgpt_slackbot',
+            handlerId: prevAns?.handlerId,
+            extra: slackMeta
+        });
     }
 }
 


### PR DESCRIPTION
1. Change chatgpt client to write response to an answer queue when received from chatgpt
2. Put reply slack logic back to Slackbot, and have slackbot listen to answer queue and post reply
3. Change default reaction emoji and allow customizing.